### PR TITLE
Capitalization prevented link from working after rendered to webpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Check out the list of examples below to get started:
 
   * [Hello World](#hello-world)
   * [Types](#types)
-  * [Initialization](#Initialization)
+  * [Initialization](#initialization)
   * [Comments](#comments)
   * [Switch](#switch)
   * [Array](#array)


### PR DESCRIPTION
On the actual rendered webpage the Initialization link doesn't seem to work. Looking at the README.md it would appear it's the only one with a different capitalization on the first letter, which I'm guessing is the problem. 